### PR TITLE
Fix typo "beaing" => "being"

### DIFF
--- a/src/Website/jobs.json
+++ b/src/Website/jobs.json
@@ -32,7 +32,7 @@
 		"description": "Title of the modal the user will see if it's not in Discord server."
 	},
 	"jobs.guild.explanation": {
-		"message": "To be able to apply you must have joined our Discord server. Otherwise we won't be able to contact you if you end up beaing selected!",
+		"message": "To be able to apply you must have joined our Discord server. Otherwise we won't be able to contact you if you end up being selected!",
 		"description": "Explanation why users should be in Discord server to perform job application."
 	},
 	"jobs.header.title": {


### PR DESCRIPTION
Small typo fix in website/jobs.json key jobs.guild.explanation