### PR TITLE
Update crowdin.yml

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,9 +1,3 @@
 files:
   - source: /en/**/*.md
-    translation: /%two_letters_code%/**/%original_file_name%
-    languages_mapping:
-      two_letters_code:
-        zh-CN: zh-CN
-        zh-TW: zh-TW
-        pt-PT: pt
-        pt-BR: pt-BR
+    translation: /%locale%/**/%original_file_name%

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,7 +1,9 @@
 files:
-  - source: /**/*.md
-    ignore:
-      - /%two_letters_code%/
-    translation: /%two_letters_code%/**/%original_file_name%
   - source: /en/**/*.md
-    translation: /%locale%/**/%original_file_name%
+    translation: /%two_letters_code%/**/%original_file_name%
+    languages_mapping:
+      two_letters_code:
+        zh-CN: zh-CN
+        zh-TW: zh-TW
+        pt-PT: pt
+        pt-BR: pt-BR


### PR DESCRIPTION
Import all files and sub-folders inside "en" folder to Crowdin. Languages mapping is added to prevent potential collisions (otherwise, both Portuguese languages will be exported to "pt" folder)